### PR TITLE
doc: add systemd service sample, fix copyright years, fix path for warpfleet resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,47 @@ This Web server aims to synchronize git repositories and serve macros for the Wa
 
 Now listen at 0.0.0.0:8082
 
+## Run as service
+
+Add `/etc/systemd/system/warp10-synchronizer.service` with following content (adjust paths to your needs):
+
+```
+[Unit]
+Description=Warp 10 - WarpFleet Synchronizer
+Documentation=https://github.com/senx/WarpFleetSynchronizer
+After=network-online.target
+
+[Service]
+Type=simple
+User=warp10
+Group=warp10
+WorkingDirectory=/path/to/warp10/synchronizer
+ExecStart=java -jar /path/to/warp10/synchronizer/bin/WarpFleetSynchronizer-all.jar /path/to/warp10/synchronizer/conf/synchronizer.conf
+Restart=on-failure
+SuccessExitStatus=143 
+
+[Install]
+WantedBy=multi-user.target
+```
+Then start service and enable at boot time:
+
+```commandline
+sudo systemctl start warp10-synchronizer
+sudo systemctl enable warp10-synchronizer
+```
+Check it works as expected:
+
+````commandline
+sudo systemctl status warp10-synchronizer
+or
+journalctl -fu warp10-synchronizer
+````
+
 ## Usage
 
 ### For WarpFleet Resolver
 
-    http://localhost:8082/macros/path/to/macro.mc2
+    http://localhost:8082/macros/<repo name>/path/to/macro.mc2
 
 
 ### API
@@ -56,7 +92,7 @@ List repositories
     http://localhost:8082/api/repos/<owner>
 
 
-> Copyright 2020  SenX S.A.S.
+> Copyright 2019-2021  SenX S.A.S.
 >
 > [https://senx.io](https://senx.io)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now listen at 0.0.0.0:8082
 
 ## Run as service
 
-Add `/etc/systemd/system/warp10-synchronizer.service` with following content (adjust paths to your needs):
+Add `/etc/systemd/system/warpfleet-synchronizer.service` with following content (adjust paths to your needs):
 
 ```
 [Unit]
@@ -48,8 +48,8 @@ After=network-online.target
 Type=simple
 User=warp10
 Group=warp10
-WorkingDirectory=/path/to/warp10/synchronizer
-ExecStart=java -jar /path/to/warp10/synchronizer/bin/WarpFleetSynchronizer-all.jar /path/to/warp10/synchronizer/conf/synchronizer.conf
+WorkingDirectory=/path/to/warpfleet/synchronizer
+ExecStart=java -jar /path/to/warpfleet/synchronizer/bin/WarpFleetSynchronizer-all.jar /path/to/warpfleet/synchronizer/conf/synchronizer.conf
 Restart=on-failure
 SuccessExitStatus=143 
 
@@ -59,16 +59,21 @@ WantedBy=multi-user.target
 Then start service and enable at boot time:
 
 ```commandline
-sudo systemctl start warp10-synchronizer
-sudo systemctl enable warp10-synchronizer
+sudo systemctl start warpfleet-synchronizer
+sudo systemctl enable warpfleet-synchronizer
 ```
 Check it works as expected:
 
-````commandline
-sudo systemctl status warp10-synchronizer
+```commandline
+sudo systemctl status warpfleet-synchronizer
 or
-journalctl -fu warp10-synchronizer
-````
+journalctl -fu warpfleet-synchronizer
+```
+
+Note:
+* Clones of git repositories will be stored in `/path/to/warpfleet/synchronizer/tmp`
+* Macros will be stored in `/path/to/warpfleet/synchronizer/macros/macros/<repo>` 
+
 
 ## Usage
 


### PR DESCRIPTION
* add systemd service sample to run WarpFleet Synchronizer
* fix years for copyrights 
* add missing repo name in url for resolver - @Giwi can you check this one, I would even think it would be only  `http://localhost:8082/macros` instead of `http://localhost:8082/macros/<repo name>path/to/macro.mc2` or oroginally`http://localhost:8082/macros/path/to/macro.mc2`